### PR TITLE
Relax Hello.compat_version check

### DIFF
--- a/cdp_client/cdp.py
+++ b/cdp_client/cdp.py
@@ -638,7 +638,7 @@ class Connection:
     def _parse_hello_message(self, message):
         data = proto.Hello()
         data.ParseFromString(message)
-        if data.compat_version != 1:
+        if data.compat_version < 1:
             logging.info('Unsupported protocol version ' + str(data.compat_version) + '.' + str(data.incremental_version))
             return False
         self._system_name = data.system_name

--- a/cdp_client/tests/fake_data.py
+++ b/cdp_client/tests/fake_data.py
@@ -156,7 +156,7 @@ def create_valid_hello_response_with_auth_required(challenge):
 def create_invalid_hello_response():
     response = proto.Hello()
     response.system_name = "foo"
-    response.compat_version = 2
+    response.compat_version = 0
     response.incremental_version = 0
     return response
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name='cdp-client',
-    version='2.0.1',
+    version='2.0.2',
     packages=find_packages(),
     install_requires=[
         'promise==2.2.1',


### PR DESCRIPTION
* relax Hello.compat_version check to allow connect to CDP 4.11 that has now compat_version = 2, with added EventList support, but otherwise is compatible with current client